### PR TITLE
Updating BSHook to 5.1.9 and actions build to use artifactsv3

### DIFF
--- a/.github/workflows/build-ndk.yml
+++ b/.github/workflows/build-ndk.yml
@@ -106,21 +106,21 @@ jobs:
       run: mv "./build/debug/${{ steps.libname.outputs.NAME }}" "./build/debug_${{ steps.libname.outputs.NAME }}"
 
     - name: Upload non-debug artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.libname.outputs.NAME }}
         path: ./build/${{ steps.libname.outputs.NAME }}
         if-no-files-found: error
 
     - name: Upload debug artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: debug_${{ steps.libname.outputs.NAME }}
         path: ./build/debug_${{ steps.libname.outputs.NAME }}
         if-no-files-found: error
 
     - name: Upload qmod artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{env.qmod_name}}.qmod
         path: ./${{ env.qmod_name }}.qmod

--- a/mod.template.json
+++ b/mod.template.json
@@ -5,7 +5,7 @@
     "author": "RedBrumbler",
     "version": "${version}",
     "packageId": "com.beatgames.beatsaber",
-    "packageVersion": "1.37.1_9895289101",
+    "packageVersion": "1.37.0_9064817954",
     "description": "Quest mod to allow users to vote on beatsaver",
     "dependencies": [],
     "lateModFiles": [

--- a/qpm.json
+++ b/qpm.json
@@ -32,7 +32,7 @@
     },
     {
       "id": "web-utils",
-      "versionRange": "^0.6.3",
+      "versionRange": "^0.6.0",
       "additionalData": {}
     },
     {
@@ -42,7 +42,7 @@
     },
     {
       "id": "bs-cordl",
-      "versionRange": "^3701.0.0",
+      "versionRange": "^3700.0.0",
       "additionalData": {}
     },
     {
@@ -59,7 +59,7 @@
     },
     {
       "id": "bsml",
-      "versionRange": "^0.4.44",
+      "versionRange": "^0.4.37",
       "additionalData": {}
     },
     {

--- a/qpm.json
+++ b/qpm.json
@@ -8,8 +8,8 @@
     "version": "0.1.0",
     "url": "https://github.com/RedBrumbler/BeatSaverVoting.Quest",
     "additionalData": {
-      "cmake": false,
-      "overrideSoName": "libbeatsavervoting.so"
+      "overrideSoName": "libbeatsavervoting.so",
+      "cmake": false
     }
   },
   "workspace": {
@@ -19,7 +19,10 @@
         "qpm qmod manifest",
         "pwsh ./scripts/createqmod.ps1 BeatSaverVoting"
       ]
-    }
+    },
+    "qmodIncludeDirs": [],
+    "qmodIncludeFiles": [],
+    "qmodOutput": null
   },
   "dependencies": [
     {
@@ -44,7 +47,7 @@
     },
     {
       "id": "beatsaber-hook",
-      "versionRange": "^5.1.7",
+      "versionRange": "^5.1.9",
       "additionalData": {}
     },
     {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -48,7 +48,7 @@
       },
       {
         "id": "beatsaber-hook",
-        "versionRange": "^5.1.7",
+        "versionRange": "^5.1.9",
         "additionalData": {}
       },
       {
@@ -99,17 +99,17 @@
     {
       "dependency": {
         "id": "web-utils",
-        "versionRange": "=0.6.6",
+        "versionRange": "=0.6.7",
         "additionalData": {
-          "soLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.6/libweb-utils.so",
-          "debugSoLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.6/debug_libweb-utils.so",
+          "soLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.7/libweb-utils.so",
+          "debugSoLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.7/debug_libweb-utils.so",
           "overrideSoName": "libweb-utils.so",
-          "modLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.6/WebUtils.qmod",
-          "branchName": "version/v0_6_6",
+          "modLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.7/WebUtils.qmod",
+          "branchName": "version/v0_6_7",
           "cmake": false
         }
       },
-      "version": "0.6.6"
+      "version": "0.6.7"
     },
     {
       "dependency": {
@@ -291,17 +291,17 @@
     {
       "dependency": {
         "id": "beatsaverplusplus",
-        "versionRange": "=0.1.5",
+        "versionRange": "=0.1.6",
         "additionalData": {
-          "soLink": "https://github.com/RedBrumbler/BeatSaverPlusPlus/releases/download/v0.1.5/libbeatsaverplusplus.so",
-          "debugSoLink": "https://github.com/RedBrumbler/BeatSaverPlusPlus/releases/download/v0.1.5/debug_libbeatsaverplusplus.so",
+          "soLink": "https://github.com/RedBrumbler/BeatSaverPlusPlus/releases/download/v0.1.6/libbeatsaverplusplus.so",
+          "debugSoLink": "https://github.com/RedBrumbler/BeatSaverPlusPlus/releases/download/v0.1.6/debug_libbeatsaverplusplus.so",
           "overrideSoName": "libbeatsaverplusplus.so",
-          "modLink": "https://github.com/RedBrumbler/BeatSaverPlusPlus/releases/download/v0.1.5/BeatSaverPlusPlus.qmod",
-          "branchName": "version/v0_1_5",
+          "modLink": "https://github.com/RedBrumbler/BeatSaverPlusPlus/releases/download/v0.1.6/BeatSaverPlusPlus.qmod",
+          "branchName": "version/v0_1_6",
           "cmake": false
         }
       },
-      "version": "0.1.5"
+      "version": "0.1.6"
     }
   ]
 }

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -33,7 +33,7 @@
       },
       {
         "id": "web-utils",
-        "versionRange": "^0.6.3",
+        "versionRange": "^0.6.0",
         "additionalData": {}
       },
       {
@@ -43,7 +43,7 @@
       },
       {
         "id": "bs-cordl",
-        "versionRange": "^3701.0.0",
+        "versionRange": "^3700.0.0",
         "additionalData": {}
       },
       {
@@ -60,7 +60,7 @@
       },
       {
         "id": "bsml",
-        "versionRange": "^0.4.44",
+        "versionRange": "^0.4.37",
         "additionalData": {}
       },
       {
@@ -84,17 +84,17 @@
     {
       "dependency": {
         "id": "bsml",
-        "versionRange": "=0.4.44",
+        "versionRange": "=0.4.43",
         "additionalData": {
-          "soLink": "https://github.com/RedBrumbler/Quest-BSML/releases/download/v0.4.44/libbsml.so",
-          "debugSoLink": "https://github.com/RedBrumbler/Quest-BSML/releases/download/v0.4.44/debug_libbsml.so",
+          "soLink": "https://github.com/RedBrumbler/Quest-BSML/releases/download/v0.4.43/libbsml.so",
+          "debugSoLink": "https://github.com/RedBrumbler/Quest-BSML/releases/download/v0.4.43/debug_libbsml.so",
           "overrideSoName": "libbsml.so",
-          "modLink": "https://github.com/RedBrumbler/Quest-BSML/releases/download/v0.4.44/BSML.qmod",
-          "branchName": "version/v0_4_44",
+          "modLink": "https://github.com/RedBrumbler/Quest-BSML/releases/download/v0.4.43/BSML.qmod",
+          "branchName": "version/v0_4_43",
           "cmake": true
         }
       },
-      "version": "0.4.44"
+      "version": "0.4.43"
     },
     {
       "dependency": {
@@ -208,10 +208,10 @@
     {
       "dependency": {
         "id": "bs-cordl",
-        "versionRange": "=3701.0.0",
+        "versionRange": "=3700.0.0",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version/v3701_0_0",
+          "branchName": "version/v3700_0_0",
           "compileOptions": {
             "includePaths": [
               "include"
@@ -226,7 +226,7 @@
           }
         }
       },
-      "version": "3701.0.0"
+      "version": "3700.0.0"
     },
     {
       "dependency": {
@@ -244,17 +244,17 @@
     {
       "dependency": {
         "id": "lapiz",
-        "versionRange": "=0.2.13",
+        "versionRange": "=0.2.12",
         "additionalData": {
-          "soLink": "https://github.com/raineio/Lapiz/releases/download/v0.2.13/liblapiz.so",
-          "debugSoLink": "https://github.com/raineio/Lapiz/releases/download/v0.2.13/debug_liblapiz.so",
+          "soLink": "https://github.com/raineio/Lapiz/releases/download/v0.2.12/liblapiz.so",
+          "debugSoLink": "https://github.com/raineio/Lapiz/releases/download/v0.2.12/debug_liblapiz.so",
           "overrideSoName": "liblapiz.so",
-          "modLink": "https://github.com/raineio/Lapiz/releases/download/v0.2.13/Lapiz.qmod",
-          "branchName": "version/v0_2_13",
+          "modLink": "https://github.com/raineio/Lapiz/releases/download/v0.2.12/Lapiz.qmod",
+          "branchName": "version/v0_2_12",
           "cmake": true
         }
       },
-      "version": "0.2.13"
+      "version": "0.2.12"
     },
     {
       "dependency": {


### PR DESCRIPTION
This is still for 1.37.0, but hoping to get a release of this to help prevent the bshook crashes that 5.1.7 can have. If released, this would also have the auth fixes you had already committed so games don't crash on auth error, which would be good for the community as v71 firmware can have auth issues. 